### PR TITLE
Sort by attack and filter pokemons with lower attack points

### DIFF
--- a/src/components/StrongAgainstList.js
+++ b/src/components/StrongAgainstList.js
@@ -52,7 +52,9 @@ export default class StrongAgainstList extends Component<void, Props, State> {
     const { strengths, weaknesses } = typeDetails;
     const pokemons = store.getPokemons().filter(({ types }) => (
       types.some(t => strengths.includes(t)) && !types.some(t => weaknesses.includes(t))
-    ));
+    ))
+    .filter(({ attack }) => pokemon.attack > attack)
+    .sort((a, b) => a.attack - b.attack);
 
     this.setState({ pokemons });
   };

--- a/src/components/WeakAgainstList.js
+++ b/src/components/WeakAgainstList.js
@@ -52,7 +52,9 @@ export default class WeakAgainstList extends Component<void, Props, State> {
     const { strengths, weaknesses } = typeDetails;
     const pokemons = store.getPokemons().filter(({ types }) => (
       types.some(t => weaknesses.includes(t)) && !types.some(t => strengths.includes(t))
-    ));
+    ))
+    .filter(({ attack }) => pokemon.attack < attack)
+    .sort((a, b) => b.attack - a.attack);
 
     this.setState({ pokemons });
   };


### PR DESCRIPTION
It would be weird if I see **Magikarp** in the **Weak against** list of my **Charmander**
